### PR TITLE
frontend: password input component autofocus on mount

### DIFF
--- a/frontends/web/src/components/password.jsx
+++ b/frontends/web/src/components/password.jsx
@@ -51,6 +51,9 @@ class PasswordSingleInputClass extends Component {
         if (this.props.pattern) {
             this.regex = new RegExp(this.props.pattern);
         }
+        if (this.props.autoFocus && this.password?.current) {
+            this.password.current.focus();
+        }
     }
 
     componentWillUnmount() {
@@ -175,6 +178,9 @@ class PasswordRepeatInputClass extends Component {
     componentDidMount() {
         if (this.props.pattern) {
             this.regex = new RegExp(this.props.pattern);
+        }
+        if (this.props.autoFocus && this.password?.current) {
+            this.password.current.focus();
         }
     }
 

--- a/frontends/web/src/routes/device/bitbox01/setup/initialize.tsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/initialize.tsx
@@ -49,8 +49,6 @@ interface State {
 }
 
 class Initialize extends Component<Props, State> {
-    private passwordInput = createRef<HTMLInputElement>();
-
     constructor(props) {
         super(props);
         this.state = {
@@ -83,13 +81,6 @@ class Initialize extends Component<Props, State> {
                     status: stateEnum.ERROR,
                     errorMessage: data.errorMessage,
                 });
-            }
-            if (this.passwordInput.current) {
-                try {
-                    (this.passwordInput.current as any).getWrappedInstance().clear();
-                } catch (e) {
-                    console.error(e);
-                }
             }
         });
     }
@@ -149,7 +140,6 @@ class Initialize extends Component<Props, State> {
                     label={t('initialize.input.label')}
                     repeatLabel={t('initialize.input.labelRepeat')}
                     repeatPlaceholder={t('initialize.input.placeholderRepeat')}
-                    ref={this.passwordInput}
                     disabled={status === stateEnum.WAITING}
                     onValidPassword={this.setValidPassword} />
                 <div className="buttons">

--- a/frontends/web/src/routes/device/bitbox01/setup/seed-create-new.jsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/seed-create-new.jsx
@@ -49,7 +49,6 @@ class SeedCreateNew extends Component {
     }
 
     walletNameInput = createRef();
-    backupPasswordInput = createRef();
 
     componentDidMount () {
         this.checkSDcard();
@@ -85,9 +84,6 @@ class SeedCreateNew extends Component {
                 });
             } else {
                 this.props.onSuccess();
-            }
-            if (this.backupPasswordInput.current) {
-                this.backupPasswordInput.current.getWrappedInstance().clear();
             }
             this.setState({ backupPassword: '' });
         });
@@ -188,7 +184,6 @@ class SeedCreateNew extends Component {
                     <PasswordRepeatInput
                         label={t('seed.password.label')}
                         repeatPlaceholder={t('seed.password.repeatPlaceholder')}
-                        ref={this.backupPasswordInput}
                         disabled={status === STATUS.CREATING}
                         onValidPassword={this.setValidBackupPassword} />
                 </div>

--- a/frontends/web/src/routes/device/bitbox01/unlock.jsx
+++ b/frontends/web/src/routes/device/bitbox01/unlock.jsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, createRef, h } from 'preact';
+import { Component, h } from 'preact';
 import { translate } from 'react-i18next';
 import { route } from 'preact-router';
 import { apiGet, apiPost } from '../../../utils/request';
@@ -41,22 +41,6 @@ class Unlock extends Component {
         remainingAttempts: null,
         needsLongTouch: false,
         password: '',
-    }
-
-    passwordInput = createRef();
-
-    componentDidMount() {
-        this.focus();
-    }
-
-    componentDidUpdate() {
-        this.focus();
-    }
-
-    focus() {
-        if (this.passwordInput.current) {
-            this.passwordInput.current.focus();
-        }
     }
 
     handleFormChange = password => {
@@ -145,7 +129,6 @@ class Unlock extends Component {
                                             <div className="m-top-default">
                                                 <PasswordSingleInput
                                                     autoFocus
-                                                    ref={this.passwordInput}
                                                     id="password"
                                                     type="password"
                                                     label={t('unlock.input.label')}


### PR DESCRIPTION
Previous to this change the BitBox01 unlock screen created a
reference to the password input and tried to focus it. AutoFocus
never worked properly with Preact 8 and becuase of that there is
logic in the code that tries to focus the input element.

This blocked createRef migration which changed the ref to using
hook-style refs with createRef. Before password input component
passed in a callback to get the ref of the input. With the
createRef migration this changed and the input element was not
found anymore and error when trying to focus.

Changed password input components to check for autoFocus prop
and trying to focus the element on mount. Tested in Qt app as it
has slightly different behavior than in the browser with webdev.